### PR TITLE
docs: add RPC latency benchmark to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,3 +348,7 @@ $ shentud tx broadcast signedTx.json
 # Check the balance of node0
 $ curl -s http:/localhost:1317/ctk/balance/$NODE0_KEY
 ```
+
+## Resources
+
+- [RPC Latency Benchmark](https://openchainbench.com/benchmarks/shentu-rpc) — independent latency and availability measurements for Shentu Chain public RPC endpoints


### PR DESCRIPTION
Adds a Resources section to the README pointing to the independent RPC latency benchmark for Shentu Chain.

[OpenChainBench](https://openchainbench.com) is an open-source benchmark suite that continuously measures latency, availability and block-height freshness across public RPC endpoints. The [Shentu Chain bench](https://openchainbench.com/benchmarks/shentu-rpc) covers the official endpoint alongside community providers (Polkachu, High Stakes), giving node operators and dApp developers objective data to choose the fastest endpoint.

The benchmark probes Tendermint `/status` with anti-cache headers on a 30-second cadence from three geographic regions (US East, EU West, AP Southeast). All code and YAML specs are open source at https://github.com/ChainBench/OpenChainBench.